### PR TITLE
Fix a link and add Polygon clarification

### DIFF
--- a/content/creator/wearables/publishing-wearables.md
+++ b/content/creator/wearables/publishing-wearables.md
@@ -26,9 +26,11 @@ For detailed instructions on how to submit your wearable collection for approval
 
 ### Publication fees 
 
-There is a required fee for publishing items. This fee was originally [voted in place by the Decentraland DAO](https://governance.decentraland.org/en/proposal/?id=50092c00-c315-11eb-ac84-1705d1ae4a66) to deter users from publishing an excessive number of wearables in an attempt to “spam” the wearables market.
+There is a required fee for publishing items. This fee was originally [voted in place by the Decentraland DAO](https://governance.decentraland.org/proposal/?id=50092c00-c315-11eb-ac84-1705d1ae4a66) to deter users from publishing an excessive number of wearables in an attempt to “spam” the wearables market.
 
-The [most recent vote](https://governance.decentraland.org/proposal/?id=b8075360-e8e7-11ec-82d9-d917cdd158ac) regarding publication fees has pegged them to a fixed amount of 150 United States dollars per item, to be paid in MANA.
+The [most recent vote](https://governance.decentraland.org/proposal/?id=b8075360-e8e7-11ec-82d9-d917cdd158ac) regarding publication fees has pegged them to a fixed amount of 150 United States dollars per item, to be paid in **Polygon MANA**. 
+
+> **Note:** You can move MANA between Ethereum and Polygon using the [Account dApp](https://account.decentraland.org).
 
 For example, if you publish a collection with two items and the price of MANA at the time is 1.5 USD, you will have to pay a fee of 200 MANA (150 USD for each item divided by the price of MANA in USD) regardless of the rarity (or how many NFTs can be minted) of those items.
 


### PR DESCRIPTION
Fixed the link to the governance proposal and metioned that MANA must be in the Polygon network to pay for publication fees, and added a note on how to move MANA between Ethereum and Polygon