### PR TITLE
Updating Partners Registry naming

### DIFF
--- a/content/creator/verified-partners/_index.md
+++ b/content/creator/verified-partners/_index.md
@@ -1,7 +1,7 @@
 ---
-title: Verified Partners
-BookHref: https://partners.decentraland.vote/
+title: Metaverse Studios
+BookHref: https://studios.decentraland.org/
 aliases:
-  - /metaverse-agencies
-  - /creator/metaverse-agencies
+  - /metaverse-studios
+  - /creator/metaverse-studios
 ---


### PR DESCRIPTION
Renaming Partners Registry into Metaverse Studios as per request of the Verified Partners Squad