### PR TITLE
docs: show colors ref as text not as code

### DIFF
--- a/content/creator/scenes/interactivity/onscreen-ui.md
+++ b/content/creator/scenes/interactivity/onscreen-ui.md
@@ -429,7 +429,5 @@ close.onClick = new OnPointerDown(() => {
   canvas.isPointerBlocker = false
 })
 ```
-````
-
 
 See [color types]({{< ref "/content/creator/sdk7/3d-essentials/color-types.md" >}}) for more details on how to set colors.


### PR DESCRIPTION
Colors page link is showing as code at the end of [this page](https://docs.decentraland.org/creator/development-guide/onscreen-ui/)
![image](https://user-images.githubusercontent.com/26650374/213413444-c156362c-b6f9-43df-9425-2bbb0f9eda74.png)

Fixed this issue in docs!