### PR TITLE
Update external-links.md

### DIFF
--- a/content/creator/sdk7/interactivity/external-links.md
+++ b/content/creator/sdk7/interactivity/external-links.md
@@ -18,12 +18,10 @@ To teleport a player to another scene, call the following function, indicating t
 ```ts
 import { teleportTo } from "~system/RestrictedActions"
 
-teleportTo('-51,1')
+teleportTo({ worldCoordinates: { x: -51, y: 1 } })
 ```
 
 Players are presented a confirmation screen before they are teleported, this screen displays information from the destination scene’s `scene.json file`, including the scene `name`, `description` and `navmapThumbnail`. See [scene metadata]({{< ref "/content/creator/sdk7/projects/scene-metadata.md" >}}) for details on how to set this data.
-
-You can also teleport players to the most crowded place in Genesis City by doing `teleportTo(‘crowd’)`, which is equivalent to typing `/goto crowd` in the chat. Similarly you can teleport players to a random location from the curated list that you reach with `/goto magic` by doing ``teleportTo(‘magic’)`.
 
 Bare in mind that teleports take you to a scene in the indicated coordinates, but not necessarily to that same coordinates. This means that when travelling to a scene that has multiple parcels, players may not be landing on the same coordinates as specified, but rather into one of the spawn points designated by the creator of the scene.
 


### PR DESCRIPTION
adjusted teleportTo("-51,1") to the syntax teleportTo({ worldCoordinates: { x: -51, y: 1 } })

removed teleportTo("crowed") or teleportTo("magic") since SDK is not allowing me use teleport that way.