### PR TITLE
feat: Add default og image to pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -97,6 +97,8 @@ enableGitInfo = true
   # Intercom App ID
   IntercomAppId = ''
   images = ['images/logo.svg']
+  [params.social]
+    twitter = 'decentraland'
 
 [outputs]
 home = ["HTML", "REDIR"]

--- a/config.toml
+++ b/config.toml
@@ -96,7 +96,7 @@ enableGitInfo = true
 
   # Intercom App ID
   IntercomAppId = ''
-
+  images = ['images/logo.svg']
 
 [outputs]
 home = ["HTML", "REDIR"]


### PR DESCRIPTION
This PR adds the Decentraland logo as the default open graph image.
Page creators can add their own images when writing the pages [by configuring the open graph parameters](https://gohugo.io/templates/embedded/#configure-open-graph) in each page.