### PR TITLE
Update avatar-modifiers.md

### DIFF
--- a/content/creator/sdk7/interactivity/avatar-modifiers.md
+++ b/content/creator/sdk7/interactivity/avatar-modifiers.md
@@ -27,7 +27,8 @@ const entity = engine.addEntity()
 
 AvatarModifierArea.create(entity, {
 	area: Vector3.create(4, 3, 4),
-	modifiers: [AvatarModifierType.HIDE_AVATARS],
+	modifiers: [AvatarModifierType.AMT_HIDE_AVATARS],
+	excludeIds: []
 })
 
 Transform.create(entity, {


### PR DESCRIPTION
Updated AvatarModifierType.AMT_DISABLE_PASSPORTS.
Added `excludeIds` since it's marked as required in `node_modules/@dcl/ecs/dist/components/generated/pb/decentraland/sdk/components/avatar_modifier_area.gen.d.ts`.

Last change should be added as well on the other examples of this page or changed on definition.