### PR TITLE
[ENHANCEMENT]: Add Note for Mac users

### DIFF
--- a/content/creator/sdk7/getting-started/SDK-101.md
+++ b/content/creator/sdk7/getting-started/SDK-101.md
@@ -104,6 +104,10 @@ Click the **<> Code** button on the top menu to open your scene project on Visua
 **📔 Note**: Install [Visual Studio Code](https://code.visualstudio.com/), if you don't have it already.
 {{< /hint >}}
 
+{{< hint warning >}}
+**📔 Note**: If you are on macOS, make sure the Visual Studio app is in the Applications directory.
+{{< /hint >}}
+
 This opens a separate window with Visual Studio Code. On the left margin you can navigate the files and folder structure of your project.
 
 <img src="/images/editor/files-on-vs-studio.png" alt="Scene name" width="300"/>


### PR DESCRIPTION
# Problem

If the Visual Studio Code app is in another folder ther than Applications, Creator Hub wont open it when CODE button is clicked.

# Solution

Add Note for Mac users to make sure the Visual Studio Code application is in the Applications folder.