### PR TITLE
Fix image tag formatting in creating-wearables.md

### DIFF
--- a/content/creator/wearables-and-emotes/wearables/creating-wearables.md
+++ b/content/creator/wearables-and-emotes/wearables/creating-wearables.md
@@ -251,7 +251,7 @@ The skin texture is made in grayscale so it allows the render engine to tint the
 Important: always preserve the UV mapping for any body part that is exposed by a wearable, like the legs exposed by the shorts or skirts.
 {{< /hint >}}
 
-<img src="/images/wearables-and-emotes/creating-wearables/19_skin_uv.png"width="600"/>
+<img src="/images/wearables-and-emotes/creating-wearables/19_skin_uv.png" width="600"/>
 
 You can create custom textures for your wearables! However, it’s always best to use a single, very small, texture file for each wearable. Using the default AvatarWearable_MAT texture provided in the example files will guarantee that your wearables are performant!
 


### PR DESCRIPTION
## Fix image tag formatting in creating-wearables.md

Corrected a typo in the formatting of an image tag in the markdown file.

The missing image is: https://github.com/decentraland/documentation/blob/main/static/images/wearables-and-emotes/creating-wearables/19_skin_uv.png

<img width="600" alt="image" src="https://github.com/user-attachments/assets/52eeee51-dcdb-4703-9a83-3ee5196ea631" />

Current page with typo:

<img width="1512" height="865" alt="image" src="https://github.com/user-attachments/assets/d4b50b93-6dba-4d76-9c36-674622c1d08b" />
